### PR TITLE
docs: add new badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/rpodcast/shinystate/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/rpodcast/shinystate/actions/workflows/R-CMD-check.yaml)
+[![r-universe version](https://rpodcast.r-universe.dev/shinystate/badges/version)](https://rpodcast.r-universe.dev/shinystate)
+[![CRAN status](https://www.r-pkg.org/badges/version/shinystate)](https://CRAN.R-project.org/package=shinystate)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[![The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Monthly Downloads](https://cranlogs.r-pkg.org/badges/shinystate](https://CRAN.R-project.org/package=shinystate)
+[![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/shinystate)](https://CRAN.R-project.org/package=shinystate)
 <!-- badges: end -->
 
 `shinystate` is an R package that provides additional customization on top of the standard Shiny [bookmarkable state](https://shiny.posit.co/r/articles/share/bookmarking-state/) capabilities.


### PR DESCRIPTION
This pull request adds new badges to the README of this repository ( closes issue #8 ):
* R-universe version
* CRAN status
* CRAN downloads
* License
