### PR TITLE
Add pull request template to .github folder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Summary
+
+Thank you for contributing to **shinystate**! Please describe the purpose and scope of your changes. Mention any updates to documentation, bookmarking logic, metadata handling, or Shiny app examples.
+
+# Related GitHub Issues and Pull Requests
+
+-   Ref: \#
+
+# Prework
+
+-   [ ] I understand and agree to the [Code of Conduct](https://github.com/rpodcast/shinystate/blob/main/CODE_OF_CONDUCT.md)
+-   [ ] I have reviewed the [Contributing Guidelines](https://github.com/rpodcast/shinystate/blob/main/CONTRIBUTING.md)
+-   [ ] I have discussed this change in an issue or pull request (if applicable)
+
+# Checklist
+
+-   [ ] I have verified that my changes pass `R CMD check`
+-   [ ] I have tested the bookmarking behavior (if applicable)
+-   [ ] I have updated documentation (e.g., README, vignettes, function comments)
+-   [ ] I have updated the `NEWS.md` file (if applicable)


### PR DESCRIPTION
This PR adds a pull request template to the .github folder.

Addresses Issue #25.
