### PR TITLE
Pkgdown badges

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,11 +3,18 @@
 on:
   push:
     branches: [main, master]
-    paths:
+    paths: &integration_paths
       - '**'
       - '!build_nixconfig.R'
       - '!default.nix'
+      - '!README.md'
+      - '!cran-comments.md'
+      - '!CRAN-SUBMISSION'
+      - '!dev_notes.md'
   pull_request:
+    branches:
+      - '**'
+    paths: *integration_paths
 
 name: R-CMD-check.yaml
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [![The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![Monthly Downloads](https://cranlogs.r-pkg.org/badges/shinystate](https://CRAN.R-project.org/package=shinystate)
+[![Monthly Downloads](https://cranlogs.r-pkg.org/badges/shinystate)](https://CRAN.R-project.org/package=shinystate)
 [![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/shinystate)](https://CRAN.R-project.org/package=shinystate)
 <!-- badges: end -->
 


### PR DESCRIPTION
# Summary

This PR addresses two issues. The README now shows the correct badge for CRAN monthly downloads, and GitHub actions for package checks are disabled when editing non-core files on pushes to main as well as pull requests by the maintainer.

# Related GitHub Issues and Pull Requests

-   Ref: #32 , #33

# Prework

-   [x] I understand and agree to the [Code of Conduct](https://github.com/rpodcast/shinystate/blob/main/CODE_OF_CONDUCT.md)
-   [x] I have reviewed the [Contributing Guidelines](https://github.com/rpodcast/shinystate/blob/main/CONTRIBUTING.md)
-   [x] I have discussed this change in an issue or pull request (if applicable)
